### PR TITLE
Restructuring how users are retrieved for DMs

### DIFF
--- a/Teams.md
+++ b/Teams.md
@@ -106,6 +106,19 @@ snippet is just an unnamed file that is downloaded by Lounge Lizard the same as 
 With Teams and the Graph API, a code snippet is also included in a message's attachments collection but it is a link to 
 another API call that must be made to retrieve the contents.
 
+* **Formatting in messages:** MS Teams and the Graph API support formatting in messages using html.  Currently, Loung Lizard uses a 
+rich text editor to compose messages but converts formatting into markdown when sending.  The application needs to be updated to 
+convert the markdown to html.  This may be relatively straightforward as the underlying issue appears to be that when the rich text 
+editor was implemented, the UI code was made responsible for converting the editor's html to markdown and this conversion simply needs
+to be pushed down to a Slack-specific class.
+
+* **Mentions:** The mechanism employed by MS Teams and the Graph API for sending mentions in a message is considerably more complex 
+than the mechanism employed by Slack.  In Slack, mentions are sent as specially-formatted text embedded in the message itself.  In 
+MS Teams, on the other hand, there are two components to sending mentions.  The first is a special html-like tag in the message body.  
+The second component is an object that is added to the message's mentions collection which contains information about the person, 
+team, or channel being mentioned.  The best way to see how the message must be formatted is to send one or more messages using the 
+MS Teams web or desktop app, use Postman to invoke the Graph API to get the message that was sent, and inspect the response.
+
 * **Team icon:** It is possible to get use the Graph API to get a photo/icon for a team but Microsoft's model for doing this is 
 quite different than Slack's model.  With Slack, the team's icon is openly available via unauthenticated http GET.  As a result, 
 the Lounge Lizard code that retrieves the icon is embedded in the UI code and is unaware of the chat service classes.  With the 

--- a/Teams.md
+++ b/Teams.md
@@ -115,6 +115,9 @@ for an account is essentially the same as the image that is returned from the Gr
 
 * **User avatars:** See **Team icon** above.  An example of a URL for the 120x120 photo for a user is https://graph.microsoft.com/v1.0/users/{{UserId}}/photos/120x120/$value.
 
+* **Getting presence/status of other users:** There is support for getting another user's presence/status via the Graph API but 
+Lounge Lizard particularly needs to be able to receive updates (a mechanism for receiving updates has not yet been identified; see more below).  See https://docs.microsoft.com/en-us/graph/api/presence-get?view=graph-rest-beta&tabs=http for more information.
+
 ## Receiving new messages in the MS Teams web application
 
 The Microsoft Teams web and desktop applications have the same need to detect updates including the arrival of new messages as does 
@@ -139,5 +142,5 @@ obtain a Skype token but the exact mechanism for doing this has not been identif
    - https://github.com/msndevs/protocol-docs/wiki/Authentication
 3. The format of the API responses is not documented and does not appear to be the same as responses from MS Graph API methods that return chat messages.
 4. There is a possibility of breaking changes in the API at any time.  Because it is not a documented public API such changes would probably not be publicized.  However, if the MS Teams desktop application relies on the same back-end APIs as the web application the possibility of breaking changes should be minimal.
-5. There may be other related API calls that must also be made to set or get important information.  For example, browser developer tools show regular calls made to API methods called **getpresence** and **reportmyactivity**.  Presumably, these methods are used to report the current user's status (i.e. available, busy, away, etc.) and get the status of other users.
+5. There may be other related API calls that must also be made to set or get important information.  For example, browser developer tools show regular calls made to API methods called **getpresence** and **reportmyactivity**.  Presumably, these methods are used to report the current user's status (i.e. available, busy, away, etc.) and get the status of other users.  See the SlackAccount class for a complete list of events for which the Slack client can received updates from the server.
 

--- a/lib/model/message-list.js
+++ b/lib/model/message-list.js
@@ -248,6 +248,10 @@ class MessageList {
     throw new Error("Should be implemented by subclasses");
   }
 
+  async getMembers() {
+    throw new Error("Should be implemented by subclasses");
+  }
+
   updateMessagePin(id, timestamp, isPinned){
     const message = this.findMessage(id, timestamp)
     if (message && message.isPinned != isPinned){

--- a/lib/service/slack/slack-channel.js
+++ b/lib/service/slack/slack-channel.js
@@ -29,6 +29,9 @@ class SlackChannel extends Channel {
     return new SlackThread(this, id)
   }
 
+  async getMembers() {
+    return await this.account.getChannelMembers(this.id)
+  }
 
   async getProfile(id, timestamp) {
     const message = this.findMessage(id, timestamp)

--- a/lib/service/slack/slack-direct-messsage.js
+++ b/lib/service/slack/slack-direct-messsage.js
@@ -7,6 +7,7 @@ class SlackDirectMessage extends DirectMessage {
     const user = account.findUserById(event.user_id)
     super(account, event.id, user ? user.name : event.name)
     this.isMember = event.is_open
+
     if (event.is_mpim) {
       this.isMultiParty = true
       this.name = this.name.replace(`-${account.currentUserName}-`, '')
@@ -26,6 +27,15 @@ class SlackDirectMessage extends DirectMessage {
       this.isRead = false
     if (event.last_read)
       this.lastReadTs = event.last_read
+  }
+
+  async getMembers() {
+    // This will not currently get members of a multi-party chat
+    let result = []
+    if (this.userId) {
+      result.push(this.account.findUserById(this.userId))
+    }
+    return result
   }
 
   getProfile(){

--- a/lib/service/teams/message-parser.js
+++ b/lib/service/teams/message-parser.js
@@ -1,9 +1,7 @@
-const stringReplaceAsync = require('string-replace-async')
-const sanitizeHtml = require('sanitize-html')
 
 const emoji = require('./emoji.json')
 
-function parseEmoji(account, size, p1) {
+function parseReaction(account, size, p1) {
   const custom = account.emoji[p1]
   if (custom)
     return `<span style="background-image: url(${custom})" class="custom size-${size} emoji"></span>`
@@ -52,150 +50,7 @@ function encodeURIs(text) {
   return newText;
 }
 
-const rules = [
-  {
-    regex: /:([a-zA-Z0-9_\-\+]+):/g,
-    replacer(account, match, p1) {
-      const r = parseEmojiFromMessage(account, 22, p1)
-      return r !== null ? r : match[0]
-    }
-  },
-  {
-    regex: /(\n\n)/g,
-    replacer() {
-      return '<span class="para-br"><br></span>'
-    }
-  },
-  {
-    regex: /(\r\n|\r|\n)/g,
-    replacer() {
-      return '<br>'
-    }
-  },
-  {
-    regex: /(^|[^\w]+)\*([^\*]+)\*([^\w]+|$)/g,
-    replacer(account, match, p1, p2, p3) {
-      return `${p1}<strong>${p2}</strong>${p3}`
-    }
-  },
-  {
-    regex: /(^|[^\w]+)_([^_]+)_([^\w]+|$)/g,
-    replacer(account, match, p1, p2, p3) {
-      return `${p1}<em>${p2}</em>${p3}`
-    }
-  },
-  {
-    regex: /(^|[^\w]+)~([^~]+)~([^\w]+|$)/g,
-    replacer(account, match, p1, p2, p3) {
-      return `${p1}<del>${p2}</del>${p3}`
-    }
-  },
-  {
-    regex: /`([^`]+)`/g,
-    replacer(account, match, p1) {
-      return `<code>${p1}</code>`
-    }
-  },
-]
-
-function runRules(account, text) {
-  for (const rule of rules)
-    text = text.replace(rule.regex, rule.replacer.bind(null, account))
-  return text
-}
-
-function parseReference(content, display) {
-  if (['!channel', '!here', '!everyone'].includes(content))
-    return `<span class="broadcast">@${content.substr(1)}</span>`
-  else
-    return display
-}
-
-function parseChannel(account, id, display) {
-  const archiveLink = `${account.url}/archives/${id}`
-  return `<a href="${archiveLink}" onclick="wey.openChannel('${id}'); return false">#${display}</a>`
-}
-
-async function parseAt(account, id) {
-  const user = await account.fetchUser(id)
-  if (!user)
-    return `@&lt;unknown user: ${id}&gt;`
-  if (id === account.currentUserId)
-    return `<span class="broadcast at">@${user.name}</span>`
-  else
-    return `<span class="at">@${user.name}</span>`
-}
-
-function parseSlackLink(account, text, shouldParseAt) {
-  let content, display
-  const match = text.match(/(.+)\|(.+)/)
-  if (match) {
-    content = match[1]
-    display = match[2]
-  } else {
-    content = display = text
-  }
-  if (content.startsWith('!')) {
-    return [true, parseReference(content, display)]
-  } else if (content.startsWith('#')) {
-    return [false, parseChannel(account, content.substr(1), display)]
-  } else if (shouldParseAt && content.startsWith('@')) {
-    const hasMention = content.substr(1) === account.currentUserId
-    return [hasMention, parseAt(account, content.substr(1))]
-  } else {
-    return [false, `<a href="${content}">${display}</a>`]
-  }
-}
-
-function parseMarkdown(account, text) {
-  // Translate markdown in text but ignore the text inside code blocks.
-  let start = 0
-  let newText = ''
-  while ((preIndex = text.indexOf('```', start)) !== -1) {
-    newText += runRules(account, text.substring(start, preIndex).trim())
-    start = preIndex + 3
-    preIndex = text.indexOf('```', start)
-    if (preIndex === -1)
-      break
-    newText += '<pre>' + text.substring(start, preIndex).trim() + '</pre>'
-    start = preIndex + 3
-  }
-  newText += runRules(account, text.substr(start).trimLeft())
-
-  // Our parser is buggy, and sometimes HTML passed from Slack is also bug, the
-  // easist way to fix this is to run sanitizeHtml.
-  return sanitizeHtml(newText, {allowedTags: false, allowedAttributes: false})
-}
-
-function teamsMarkdownToHtmlSync(account, text) {
-  text = text.replace(/<([^<>]+)>/g, (_, p1) => parseSlackLink(account, p1, false)[1])
-  return parseMarkdown(account, text)
-}
-
-async function parseLinks(account, text) {
-  let anyHasMention = false
-  text = await stringReplaceAsync(text, /<([^<>]+)>/g, async (_, p1) => {
-    const [hasMention, result] = parseSlackLink(account, p1, true)
-    if (hasMention)
-      anyHasMention = true
-    if (result instanceof Promise)
-      return await result
-    else
-      return result
-  })
-  return [anyHasMention, text]
-}
-
 async function teamsMarkdownToHtml(text) {
-  /***
-   * TODO (fall2020):
-   * Need to determine if we need to do any other processing here (i.e. for
-   * other formatting such as bold text, etc).  Current expectation is that
-   * we will not because, while the Slack API apparently returns Markdown which
-   * must be converted to HTML for display in the UI, the Graph API returns either 
-   * plain text or HTML, either of which should be able to be displayed as-is.
-   */
-
   const atTagBegin = /<at id="[0-9]+">/g
   const atTagEnd = /<\/at>/g
 
@@ -209,4 +64,4 @@ async function teamsMarkdownToHtml(text) {
   return [hasMention, result]
 }
 
-module.exports = {parseEmoji, parseEmojiFromMessage, teamsMarkdownToHtml, teamsMarkdownToHtmlSync}
+module.exports = {parseReaction, parseEmojiFromMessage, teamsMarkdownToHtml}

--- a/lib/service/teams/teams-account.js
+++ b/lib/service/teams/teams-account.js
@@ -1,14 +1,10 @@
-// const bounds = require('binary-search-bounds')
 
 const Account = require('../../model/account')
 const TeamsMessage = require('./teams-message')
 const TeamsChannel = require('./teams-channel')
 const TeamsDirectMessage = require('./teams-direct-messsage')
-// const TeamsReaction = require('./teams-reaction')
 const TeamsUser = require('./teams-user')
 const TeamsApiHelper = require('./teams-api-helper')
-
-const TestData = require('./testdata.json')
 
 function compareChannel(a, b) {
   const nameA = a.name.toUpperCase()
@@ -36,6 +32,18 @@ function compareChannel(a, b) {
   return -1
 }
 
+const userPresenceMap = {
+  Available: "Available",
+  AvailableIdle: "Idle",
+  Away: "Away",
+  BeRightBack: "Be Right Back",
+  Busy: "Busy",
+  BusyIdle: "Idle",
+  DoNotDisturb: "Do Not Disturb",
+  Offline: "Offline",
+  PresenceUnknown: "Unknown"
+}
+
 class TeamsAccount extends Account {
   constructor(service, id, name, token) {
     super(service, id, name)
@@ -46,12 +54,7 @@ class TeamsAccount extends Account {
   setupTeamsClient(token) {
     this.apiHelper = new TeamsApiHelper(token)
 
-    this.apiHelper.on(this.apiHelper.events.TEST_EVENT, this.handleTestEvent.bind(this));
-    this.apiHelper.on(this.apiHelper.events.TEST_EVENT_WITH_PARAM, this.handleTestEventWithParam.bind(this, 77));
 
-    // require('./private-apis').extend(this.rtm)
-    // this.rtm.once('authenticated', this.ready.bind(this))
-    // this.rtm.start({ batch_presence_aware: true })
     this.ready();
 
     // Indicate whether this is reconnection.
@@ -61,55 +64,22 @@ class TeamsAccount extends Account {
     // something external to tell us when it is ok to invoke this.
     this.handleConnection();
 
-    /***
-     * TODO (fall2020): 
-     * Determine which of the events listed below can be supported with MS Teams
-     * and implement
-     */
-    // this.rtm.on('error', this.reportError.bind(this))
-    // this.rtm.on('connected', this.handleConnection.bind(this))
-    // this.rtm.on('disconnected', this.handleDisconnection.bind(this))
-    // this.rtm.on('connecting', this.handleConnecting.bind(this))
-    // this.rtm.on('reconnecting', this.handleConnecting.bind(this))
-
+    // Register event handlers for any events that can be raised by the API Helper
+    // and which will be handled here.  See the SlackAccount class for a complete list 
+    // of events for which the Slack client can received updates from the server.
     this.apiHelper.on(this.apiHelper.events.MESSAGE, this.dispatchMessage.bind(this))
-    // this.rtm.on('reaction_added', this.setReaction.bind(this, true))
-    // this.rtm.on('reaction_removed', this.setReaction.bind(this, false))
-    // this.rtm.on('star_added', this.setStar.bind(this, true))
-    // this.rtm.on('star_removed', this.setStar.bind(this, false))
-
-    // this.rtm.on('channel_marked', this.markRead.bind(this))
-    // this.rtm.on('group_marked', this.markRead.bind(this))
-    // this.rtm.on('im_marked', this.markRead.bind(this))
-
-    // this.rtm.on('channel_history_changed', this.reloadHistory.bind(this))
-    // this.rtm.on('group_history_changed', this.reloadHistory.bind(this))
-
-    // this.rtm.on('channel_joined', this.joinChannel.bind(this))
-    // this.rtm.on('group_joined', this.joinChannel.bind(this))
-    // this.rtm.on('group_open', this.joinChannel.bind(this))
-
-    // this.rtm.on('im_open', this.openDM.bind(this))
-    // this.rtm.on('conversations.open', this.joinDM.bind(this))
-
-    // this.rtm.on('im_close', this.closeDM.bind(this))
-    // this.rtm.on('group_close', this.closeDM.bind(this))
-
-    // this.rtm.on('channel_archive', this.leaveChannel.bind(this))
-    // this.rtm.on('channel_deleted', this.leaveChannel.bind(this))
-    // this.rtm.on('channel_left', this.leaveChannel.bind(this))
-    // this.rtm.on('group_archive', this.leaveChannel.bind(this))
-    // this.rtm.on('group_left', this.leaveChannel.bind(this))
-
-    // this.rtm.on('presence_change', this.handlePresenceChange.bind(this))
-
+    this.apiHelper.on(this.apiHelper.events.TEST_EVENT, this.handleTestEvent.bind(this));
+    this.apiHelper.on(this.apiHelper.events.TEST_EVENT_WITH_PARAM, this.handleTestEventWithParam.bind(this, 77));
   }
 
+  // This is just an example of an event handler
   handleTestEvent(eventParam) {
     console.log("Test event");
     console.log(eventParam);
   }
 
+  // This is just an example of an event handler with an additional constant parameter
+  // that is defined when the event handler is registered.
   handleTestEventWithParam(myParam, eventParam) {
     console.log("Test event with param");
     console.log("My param: " + myParam);
@@ -129,21 +99,8 @@ class TeamsAccount extends Account {
     this.currentUserId = currentUser.id;
     this.currentUserName = currentUser.displayName;
 
-    // Fetch custom emojis
-    await this.updateEmoji()
-
     // Fetch channels.
     await this.updateChannels()
-
-  }
-
-  async updateEmoji() {
-    /***
-     * TODO (fall2020): 
-     * Determine if there is a way to get an emoji list with the MS Graph API
-     * (and also determine how this list is used).
-     */
-    this.emoji = {}
   }
 
   async updateChannels() {
@@ -175,18 +132,7 @@ class TeamsAccount extends Account {
     this.dms = chatsWithMembers.map((c) => new TeamsDirectMessage(this, c))
 
       // Notify.
-    this.updatePresenceSubscription()
     this.channelsLoaded()
-  }
-
-  updatePresenceSubscription() {
-    /***
-     * TODO (fall2020): 
-     * Determine how we can tell (with the MS Graph API) what a user's status 
-     * (i.e. Available, Busy, etc.) is and, more importantly, when it has changed.
-     * See https://docs.microsoft.com/en-us/graph/api/presence-get?view=graph-rest-beta&tabs=http
-     */
-    console.log("updatePresenceSubscription: " + this.dms.map(dm => dm.userId));
   }
 
   reportError(error) {
@@ -203,186 +149,24 @@ class TeamsAccount extends Account {
       this.isReconnect = true
   }
 
-  // handleDisconnection() {
-  //   for (const c of this.channels)
-  //     c.clear()
-  //   this.status = 'disconnected'
-  //   this.onUpdateConnection.dispatch()
-  // }
-
-  // handleConnecting() {
-  //   this.status = 'connecting'
-  //   this.onUpdateConnection.dispatch()
-  // }
-
   async dispatchMessage(event) {
     const channel = this.findChannelById(event.channel)
     if (!channel)
       return
-  //   switch (event.subtype) {
-  //     case 'message_deleted': {
-  //       if (event.previous_message.thread_ts) {
-  //         // Emit event in thread if it is opened.
-  //         const thread = channel.findThread(event.previous_message.thread_ts)
-  //         if (thread)
-  //           thread.deleteMessage(event.deleted_ts, event.deleted_ts)
-  //       }
-  //       // Emit event in channel if the message does not belong to a thread, or
-  //       // if it is parent of a thread.
-  //       if (event.previous_message.thread_ts === undefined ||
-  //         event.previous_message.thread_ts === event.previous_message.ts)
-  //         channel.deleteMessage(event.deleted_ts, event.deleted_ts)
-  //       break
-  //     }
 
-  //     case 'message_changed': {
-  //       // When changing a thread message due to replyCount change, Slack only
-  //       // passes partial information.
-  //       let isPartialChange = false
-  //       if (event.message.thread_ts && event.message.thread_ts === event.message.ts) {
-  //         const original = channel.findMessage(event.message.ts, event.message.ts)
-  //         if (original && event.message.reply_count !== original.replyCount)
-  //           isPartialChange = true
-  //       }
-  //       // For non-partial change, simply modify the message.
-  //       if (!isPartialChange) {
-  //         const modified = new TeamsMessage(this, event.message)
-  //         await modified.fetchPendingInfo(this)
-  //         if (modified.threadId) {
-  //           // Emit event in thread if it is opened.
-  //           const thread = channel.findThread(modified.threadId)
-  //           if (thread)
-  //             thread.modifyMessage(modified.id, modified.timestamp, modified)
-  //         }
-  //         // Emit event in channel if the message does not belong to a thread, or
-  //         // if it is parent of a thread.
-  //         if (!modified.threadId || modified.isThreadHead)
-  //           channel.modifyMessage(modified.id, modified.timestamp, modified)
-  //         break
-  //       }
-  //       // Else fallback to next stage.
-  //     }
+    const message = new TeamsMessage(this, event.message)
 
-  //     case 'message_replied': {
-  //       // Slack only pass partial information when a message is replied, so
-  //       // find the original message and modify replyCount.
-  //       const original = channel.findMessage(event.message.ts, event.message.ts)
-  //       if (!original)
-  //         break
-  //       const partial = new TeamsMessage(this, event.message)
-  //       await partial.fetchPendingInfo(this)
-  //       original.isThreadParent = partial.isThreadParent
-  //       original.replyCount = partial.replyCount
-  //       original.replyUsers = partial.replyUsers
-  //       // Emit for channel and thread.
-  //       const thread = channel.findThread(partial.threadId)
-  //       if (thread)
-  //         thread.modifyMessage(original.id, original.timestamp, original)
-  //       channel.modifyMessage(original.id, original.timestamp, original)
-  //       break
-  //     }
-
-  //     default: {
-        const message = new TeamsMessage(this, event.message)
-  //       await message.fetchPendingInfo(this)
-        // if (message.threadId) {
-  //         // Emit event in thread if it is opened.
-  //         const thread = channel.findThread(message.threadId)
-  //         if (thread)
-  //           thread.dispatchMessage(message)
-  //       }
-        // Emit event in channel if the message does not belong to a thread, or
-        // if it is parent of a thread.
-        if (!message.threadId || message.isThreadHead) {
-          channel.dispatchMessage(message)
-        }
-  //     }
-  //   }
+    // Emit event in channel if the message does not belong to a thread, or
+    // if it is parent of a thread.
+    if (!message.threadId || message.isThreadHead) {
+      channel.dispatchMessage(message)
+    }
   }
-
-  // setReaction(add, event) {
-  //   const channel = this.findChannelById(event.item.channel)
-  //   if (!channel)
-  //     return
-  //   const reaction = new TeamsReaction(this, event.reaction, 1, [event.user])
-  //   if (add)
-  //     channel.reactionAdded(event.item.ts, event.item.ts, reaction)
-  //   else
-  //     channel.reactionRemoved(event.item.ts, event.item.ts, reaction)
-  // }
-
-  // setStar(hasStar, event) {
-  //   if (event.item.type !== 'message')  // Only support message for now.
-  //     return
-  //   const channel = this.findChannelById(event.item.channel)
-  //   if (channel)
-  //     channel.updateMessageStar(event.item.message.ts, event.item.message.ts, hasStar)
-  // }
-
-  // markRead(event) {
-  //   const channel = this.findChannelById(event.channel)
-  //   if (channel)
-  //     channel.markRead()
-  // }
-
-  // reloadHistory(event) {
-  //   // TODO Reload chat.
-  //   const channel = this.findChannelById(event.channel)
-  //   if (channel)
-  //     channel.clear()
-  // }
-
-  // async joinChannel(event) {
-  //   let channel
-  //   if (event.type === 'group_open') {
-  //     const group = (await this.rtm.webClient.conversations.info({ channel: event.channel })).channel
-  //     channel = new TeamsChannel(this, group)
-  //   } else {
-  //     channel = new TeamsChannel(this, event.channel)
-  //   }
-  //   const i = bounds.gt(this.channels, channel, compareChannel)
-  //   this.channels.splice(i, 0, channel)
-  //   this.onAddChannel.dispatch(i, channel)
-  // }
-
-  // leaveChannel(event) {
-  //   const index = this.channels.findIndex((c) => c.id == event.channel)
-  //   if (index === -1)
-  //     return
-  //   this.onRemoveChannel.dispatch(index, this.channels[index])
-  //   this.channels.splice(index, 1)
-  // }
-
-  // handlePresenceChange(event) {
-  //   const user = this.findUserById(event.user)
-  //   if (!user)
-  //     return
-  //   user.setAway(event.presence === 'away')
-  //   const userChannel = this.findChannelByUserId(user.id)
-  //   if (userChannel)
-  //     userChannel.setAway(event.presence === 'away')
-  // }
-
-  // async openDM(event) {
-  //   const channel = new TeamsDirectMessage(this, event)
-  //   this.dms.unshift(channel)
-  //   this.updatePresenceSubscription()
-  //   this.onOpenDM.dispatch(0, channel)
-  // }
 
   async joinDM(us) {
     const channel = this.findChannelByUserId(us)
     return channel ? channel.id : null;
   }
-
-  // async closeDM(event) {
-  //   const index = this.dms.findIndex((c) => c.id == event.channel)
-  //   if (index === -1)
-  //     return
-  //   this.onCloseDM.dispatch(index, this.dms[index])
-  //   this.dms.splice(index, 1)
-  //   this.updatePresenceSubscription()
-  // }
 
   // Save user for ID lookup
   saveUser(member) {
@@ -405,12 +189,8 @@ class TeamsAccount extends Account {
   }
 
   async disconnect() {
-    /***
-     * TODO (fall2020):
-     * Determine if we need to do anything here for MS Teams
-     */
-    // if (this.rtm.connected)
-    //   this.rtm.disconnect()
+    // Nothing to do here but we must override the disconnect method from the 
+    // base class to avoid errors when the user disconnects from an account.
   }
 
   async reload() {
@@ -423,34 +203,50 @@ class TeamsAccount extends Account {
 
   // For MS Teams, it seems that all members of the team are automatically members of all channels in the team
   async getChannelMembers(channelId) {
-    return this.getAllUsers();
+    const channel = this.findChannelById(channelId)
+
+    if (channel && channel.type === 'dm') {
+      // If "channel" is a direct message/chat, just return the participating users
+      const chatMembers = channel.memberIds.map(u => this.findUserById(u))
+      return chatMembers
+    } else {
+      // otherwise, return all users in the team
+      return this.getAllUsers();
+    }
   }
 
-  /***
-   * TODO (fall2020):
-   * Need to figure out how to get presence.  For slack, only possible values are "active" or "away"
-   * See elsewhere in this file for more info about presence in MS Teams
-   */
   async getUserPresence(userId) {
-    return null
+    const userPresence = await this.apiHelper.getUserPresence(userId)
+
+    if (userPresence && userPresence.availability) {
+      return userPresenceMap[userPresence.availability]
+    } else {
+      return null
+    }
   }
 
   async join(channel) {
-    /*** TODO (fall2020):
-     * Determine what, if anything, we need to do here
+    /***
+     * MS Teams does not have the concept of joining a channel the same way that Slack does.
+     * In MS Teams, a channel is either available to the user or it is not.  In the MS Teams
+     * application, a user may show and hide channels and support for that functionality could 
+     * be added to Lounge Lizard in the future.
+     * 
+     * In the meantime, this method must be overridden because otherwise an exception is thrown 
+     * by this method in the base class
      */
-    // await this.rtm.webClient.conversations.join({ channel: channel.id })
   }
 
   async leave(channel) {
     /***
-     * TODO (fall2020):
-     * Determine what, if anything, we need to do here
+     * MS Teams does not have the concept of leaving a channel the same way that Slack does.
+     * In MS Teams, a channel is either available to the user or it is not.  In the MS Teams
+     * application, a user may show and hide channels and support for that functionality could 
+     * be added to Lounge Lizard in the future.
+     * 
+     * In the meantime, this method must be overridden because otherwise an exception is thrown 
+     * by this method in the base class
      */
-    // if (channel.type === 'channel')
-    //   await this.rtm.webClient.conversations.leave({ channel: channel.id })
-    // else
-    //   await this.rtm.webClient.conversations.close({ channel: channel.id })
   }
 }
 

--- a/lib/service/teams/teams-account.js
+++ b/lib/service/teams/teams-account.js
@@ -117,13 +117,17 @@ class TeamsAccount extends Account {
       // Chat member list includes current user, so need to filter that out here...
       const filteredChatMembers = chatMembers.filter(m => !(m.userId === this.currentUserId) )
 
+      const chatMemberIds = filteredChatMembers.map(m => {return m.userId})
+      const chatMemberPresence = await this.apiHelper.getPresencesByUserId(chatMemberIds)
+
       return {
         id: c.id,
         topic: c.topic,
         createdDateTime: c.createdDateTime,
         lastUpdatedDateTime: c.lastUpdatedDateTime,
         memberName: filteredChatMembers.map(m => {return m.displayName }),
-        memberId: filteredChatMembers.map(m => {return m.userId})
+        memberId: chatMemberIds,
+        memberPresence: chatMemberPresence
       };
     });
 

--- a/lib/service/teams/teams-api-helper.js
+++ b/lib/service/teams/teams-api-helper.js
@@ -41,6 +41,7 @@ const apiPaths = {
   getChats: "/beta/chats",
   getCurrentUser: "/v1.0/me",
   getTeamMembers: "/v1.0/groups/{{TeamId}}/members",
+  getPresencesByUserId: "/beta/communications/getPresencesByUserId",
   getUser: "/v1.0/users/{{UserId}}",
   getUserPresence: "/beta/users/{{UserId}}/presence",
   sendChannelMessage: "/beta/teams/{{TeamId}}/channels/{{ChannelId}}/messages",
@@ -268,6 +269,21 @@ class TeamsApiHelper {
   async getCurrentUser() {
     const response = await this.invokeTeamsApi(apiPaths.getCurrentUser, 'get');
     return response;
+  }
+
+  /***
+   * See https://docs.microsoft.com/en-us/graph/api/cloudcommunications-getpresencesbyuserid?view=graph-rest-beta&tabs=http
+   * 
+   * Note: userIdList must be an array of strings
+   */
+  async getPresencesByUserId(userIdList) {
+    const path = apiPaths.getPresencesByUserId
+    const data = {
+      ids: userIdList
+    }
+
+    const response = await this.invokeTeamsApi(path, 'post', data)
+    return response.value
   }
 
   async getTeamMembers(teamId) {

--- a/lib/service/teams/teams-api-helper.js
+++ b/lib/service/teams/teams-api-helper.js
@@ -24,12 +24,8 @@ const apiHost = "https://graph.microsoft.com"
 const loginHost = "https://login.microsoftonline.com"
 
 /***
- * TODO (fall2020):
- * In accordance with the REST paradigm, the paths for "send" and "get" of a given resource
- * are the same (see getChatMessages and sendChatMessages, for example) with the distinction
- * between sending and getting being determined by the http verb used for the API call.  
- * Considering this, it probably makes sense to change the paths constant below to just 
- * define each path once and to remove the verb from the name of each member of the constant.
+ * The paths for sending messages are the same as the paths for retrieving the same type of message(s) (i.e. 
+ * channel messages).  They are repeated in the object below for clarity and ease of use.
  */
 const apiPaths = {
   getChannelMessage: "/beta/teams/{{TeamId}}/channels/{{ChannelId}}/messages/{{MessageId}}",
@@ -49,9 +45,16 @@ const apiPaths = {
   sendChatMessage: "/beta/chats/{{ChatId}}/messages"
 }
 
+/***
+ * Using the tenant "organizations" here means that users will only be able to use the application 
+ * with a work/school account (i.e. an account created by an organization to which the user belongs).
+ * This probably makes sense given the fact that the whole idea behind MS Teams is that the user belongs 
+ * to a team which, in turn, belongs to an organization.  If it becomes necessary to support non-organization
+ * accounts, the tenant in the paths below should be changed to "common".
+ */
 const loginPaths = {
-  deviceAuthorizationRequest: "/{{TenantID}}/oauth2/v2.0/devicecode",
-  getAccessToken: "/{{TenantID}}/oauth2/v2.0/token",
+  deviceAuthorizationRequest: "/organizations/oauth2/v2.0/devicecode",
+  getAccessToken: "/organizations/oauth2/v2.0/token",
 
 }
 
@@ -120,29 +123,16 @@ class TeamsApiHelper {
   // This will eventually become part of the flow for adding a new account
   // to the application
   async getDeviceCode() {
-    /***
-     * TODO (fall2020):
-     * The tenant used below for the device code auth flow is "organizations".  It can
-     * also be "common", "consumers", or an individual tenant id.  We need to figure 
-     * out what the ramifications are of using different tenant ids here.
-     */
-    const path = loginPaths.deviceAuthorizationRequest.replace("{{TenantID}}", "organizations")
-
-    /***
-     * TODO (fall2020):
-     * Need to figure out best values to send for "scope" here
-     * See https://docs.microsoft.com/en-us/graph/permissions-reference
-     */
     const options = {
       baseURL: loginHost,
-      url: path,
+      url: loginPaths.deviceAuthorizationRequest,
       method: 'post',
       headers: {
         'Content-Type': 'application/x-www-form-urlencoded'
       },
       data: qs.stringify({
         client_id: authParameters.clientId,
-        scope: 'user.read offline_access openid profile email chat.readwrite'
+        scope: 'user.read offline_access openid profile email chat.readwrite presence.read.all'
       })
     }
 
@@ -163,17 +153,9 @@ class TeamsApiHelper {
   // This will eventually become part of the flow for adding a new account
   // to the application
   async getAuthTokenFromDeviceCode() {
-    /***
-     * TODO (fall2020):
-     * The tenant used below for the device code auth flow is "organizations".  It can
-     * also be "common", "consumers", or an individual tenant id.  We need to figure 
-     * out what the ramifications are of using different tenant ids here.
-     */
-    const path = loginPaths.getAccessToken.replace("{{TenantID}}", "organizations")
-
     const options = {
       baseURL: loginHost,
-      url: path,
+      url: loginPaths.getAccessToken,
       method: 'post',
       headers: {
         'Content-Type': 'application/x-www-form-urlencoded'
@@ -197,17 +179,9 @@ class TeamsApiHelper {
   }
 
   async getAccessToken() {
-    /***
-     * TODO (fall2020):
-     * The tenant used below for the device code auth flow is "common".  It can
-     * also be "organizations", "consumers", or an individual tenant id.  We need to figure 
-     * out what the ramifications are of using different tenant ids here.
-     */
-    const path = loginPaths.getAccessToken.replace("{{TenantID}}", "common")
-
     const options = {
       baseURL: loginHost,
-      url: path,
+      url: loginPaths.getAccessToken,
       method: 'post',
       headers: {
         'Content-Type': 'application/x-www-form-urlencoded'
@@ -305,11 +279,6 @@ class TeamsApiHelper {
     const response = await this.invokeTeamsApi(path, 'get');
     return response;
   }
-
-  /***
-   * TODO (fall2020):
-   * Add helper method to do path token replacement?
-   */
 
   async sendMessage(path, message) {
     const data = {

--- a/lib/service/teams/teams-api-helper.js
+++ b/lib/service/teams/teams-api-helper.js
@@ -42,6 +42,7 @@ const apiPaths = {
   getCurrentUser: "/v1.0/me",
   getTeamMembers: "/v1.0/groups/{{TeamId}}/members",
   getUser: "/v1.0/users/{{UserId}}",
+  getUserPresence: "/beta/users/{{UserId}}/presence",
   sendChannelMessage: "/beta/teams/{{TeamId}}/channels/{{ChannelId}}/messages",
   sendChannelMessageReply: "/beta/teams/{{TeamId}}/channels/{{ChannelId}}/messages/{{MessageId}}/replies",
   sendChatMessage: "/beta/chats/{{ChatId}}/messages"
@@ -274,8 +275,17 @@ class TeamsApiHelper {
     return await this.invokeTeamsApiGetCollection(path) 
   }
 
-  async getUser(userid) {
-    const path = apiPaths.getUser.replace("{{UserId}}", userid);
+  async getUser(userId) {
+    const path = apiPaths.getUser.replace("{{UserId}}", userId);
+    const response = await this.invokeTeamsApi(path, 'get');
+    return response;
+  }
+
+  /***
+   * See https://docs.microsoft.com/en-us/graph/api/presence-get?view=graph-rest-beta&tabs=http
+   */
+  async getUserPresence(userId) {
+    const path = apiPaths.getUserPresence.replace("{{UserId}}", userId)
     const response = await this.invokeTeamsApi(path, 'get');
     return response;
   }

--- a/lib/service/teams/teams-api-helper.js
+++ b/lib/service/teams/teams-api-helper.js
@@ -314,6 +314,7 @@ class TeamsApiHelper {
   async sendMessage(path, message) {
     const data = {
       "body": {
+        "contentType": "html",
         "content": message
       }
     }

--- a/lib/service/teams/teams-channel.js
+++ b/lib/service/teams/teams-channel.js
@@ -18,6 +18,9 @@ class TeamsChannel extends Channel {
     return new TeamsThread(this, threadMessages[0])
   }
 
+  async getMembers() {
+    return await this.account.getChannelMembers(this.id)
+  }
 
   async getProfile(id, timestamp) {
     const message = this.findMessage(id, timestamp)

--- a/lib/service/teams/teams-channel.js
+++ b/lib/service/teams/teams-channel.js
@@ -67,9 +67,8 @@ class TeamsChannel extends Channel {
     // reverse chronological order, so always reverse the list of messages here.  Note that 
     // this could change if the API method used to retrieve messages is changed.
     const smsgs = messages.reverse().map((m) => new TeamsMessage(this.account, m))
-    smsgs.forEach(m => {
-      m.fetchPendingInfo(this.account);
-    });
+    for (const m of smsgs)  // need to get additional info.
+      await m.fetchPendingInfo(this.account)
 
     return smsgs
   }

--- a/lib/service/teams/teams-channel.js
+++ b/lib/service/teams/teams-channel.js
@@ -39,12 +39,7 @@ class TeamsChannel extends Channel {
     throw new Error('Saving messages is not supported for MS Teams');
   }
 
-  async openReactPicker(id, timestamp, channelId = this.id) {
-    /***
-     * TODO (fall2020): 
-     * Determine if MS Teams (and the Graph API) support custom emoji and, 
-     * if so, add code below to get custom emoji list
-     */
+  async openReactPicker(id, timestamp) {
     const message = this.findMessage(id, timestamp);
 
     const size = 22;
@@ -64,18 +59,14 @@ class TeamsChannel extends Channel {
     throw new Error('Reacting to messages is not supported for MS Teams.');
   }
 
-  /***
-   * TODO (fall2020):
-   * Slack client must always return messages in reverse chronological order because
-   * the SlackChannel implementation simply reverses the retrieved list of messages
-   * for a channel without attempting to sort it based on any property of messages.
-   * For now, we can do the same for MS Teams but ultimately need to confirm this behavior
-   * and either leave the code below as-is, or change to sort based on some message property
-   * such as last modified time.
-   */
   async readMessagesImpl() {
     const messages = await this.account.apiHelper.getChannelMessages(this.account.id, this.id);
+
+    // This behavior is undocumented but the Graph API always seems to return messages in 
+    // reverse chronological order, so always reverse the list of messages here.  Note that 
+    // this could change if the API method used to retrieve messages is changed.
     const smsgs = messages.reverse().map((m) => new TeamsMessage(this.account, m))
+
     for (const m of smsgs)  // need to get additional info.
       await m.fetchPendingInfo(this.account)
     return smsgs
@@ -92,12 +83,8 @@ class TeamsChannel extends Channel {
   }
 
   //replace @tags with appropriate tag syntax
+  // This will need to be updated when support for sending @mentions is added to Lounge Lizard
   async parseTags(text){
-    /***
-     * TODO (fall2020):
-     * Determine what needs to be done here.  At the very least, Teams
-     * does not seem to support the @everyone or @here tags.
-     */
     if (text.includes('@')){
       //for special mentions
       text = text.replace('@everyone', '<!everyone>')

--- a/lib/service/teams/teams-channel.js
+++ b/lib/service/teams/teams-channel.js
@@ -131,13 +131,11 @@ class TeamsChannel extends Channel {
   }
 
   async notifyReadImpl() {
-    if (!this.latestTs)
-      return
     /***
-     * TODO (fall2020): 
-     * Determine what to do here...
-     * On initial inspection, the MS Graph API does not seem to provide a way to mark 
-     * a channel as "read".
+     * The MS Graph API does not expose a method for setting the ID of the last message 
+     * that has been read by the user.  However, the base class will throw an exception 
+     * if this method is not implemented in child classes, so we must have this here even
+     * though it does not do anything.
      */
   }
 }

--- a/lib/service/teams/teams-direct-messsage.js
+++ b/lib/service/teams/teams-direct-messsage.js
@@ -88,9 +88,11 @@ class TeamsDirectMessage extends DirectMessage {
   }
 
   async notifyReadImpl() {
-    /*****
-     * TODO (fall2020):
-     * - Update to use MS Graph API to mark all messages in chat as read
+    /***
+     * The MS Graph API does not expose a method for setting the ID of the last message 
+     * that has been read by the user.  However, the base class will throw an exception 
+     * if this method is not implemented in child classes, so we must have this here even
+     * though it does not do anything.
      */
   }
 }

--- a/lib/service/teams/teams-direct-messsage.js
+++ b/lib/service/teams/teams-direct-messsage.js
@@ -88,11 +88,6 @@ class TeamsDirectMessage extends DirectMessage {
   }
 
   async sendMessage(text) {
-    /***
-     * TODO (fall2020):
-     * Need to deal with tags as is done in the TeamsChannel class
-     */
-
     const response = await this.account.apiHelper.sendChatMessage(this.id, text);
 
     const message = new TeamsMessage(this.account, response)

--- a/lib/service/teams/teams-direct-messsage.js
+++ b/lib/service/teams/teams-direct-messsage.js
@@ -49,6 +49,10 @@ class TeamsDirectMessage extends DirectMessage {
     this.isMember = true
   }
 
+  getMembers() {
+    return TeamsChannel.prototype.getMembers.apply(this, arguments)
+  }
+
   getProfile(){
     return TeamsChannel.prototype.getProfile.apply(this, arguments)
   }

--- a/lib/service/teams/teams-direct-messsage.js
+++ b/lib/service/teams/teams-direct-messsage.js
@@ -4,7 +4,6 @@ const TeamsMessage = require("./teams-message")
 
 class TeamsDirectMessage extends DirectMessage {
   constructor(account, event) {
-    // const user = account.findUserById(event.user_id)
     const user = event.memberName.length > 0 ? event.memberName[0] : "";
     super(account, event.id, user)
 
@@ -28,6 +27,9 @@ class TeamsDirectMessage extends DirectMessage {
       if (this.userId === account.currentUserId)
         this.name = `${this.name} (you)`
     }
+
+    // Save list of user ids for future use
+    this.memberIds = event.memberId
 
     this.mentions = 0;
     this.isRead = false;

--- a/lib/service/teams/teams-direct-messsage.js
+++ b/lib/service/teams/teams-direct-messsage.js
@@ -7,32 +7,45 @@ class TeamsDirectMessage extends DirectMessage {
     const user = event.memberName.length > 0 ? event.memberName[0] : "";
     super(account, event.id, user)
 
-    /*****
-     * TODO (fall2020): 
-     * - Get mention count (or dm count?) and assign to this.mentions
-     * - Get away status for participants
-     * - Determine if there are unread messages in this chat and assign this.isRead accordingly
-     * - Set this.lastReadTs to timestamp of last read message
-     * - Determine what, if anything, should be assigned to this.isMember
-     */
-
     if (event.memberName.length > 1) {
       this.isMultiParty = true;
       // If this is a multi-party chat, name is a comma-delimited list of participants
-      // TODO (fall2020): remove current user by matching on id
       this.name = event.memberName.join(', ');
     } else {
       this.isMultiParty = false;
       this.userId = event.memberId.length > 0 ? event.memberId[0] : null;
       if (this.userId === account.currentUserId)
         this.name = `${this.name} (you)`
+
+      if (this.userId) {
+        const presence = event.memberPresence && event.memberPresence.length > 0 ? event.memberPresence[0].availability : ''
+        this.isAway = (presence === 'Offline' || presence === 'Away')
+      }
     }
 
     // Save list of user ids for future use
     this.memberIds = event.memberId
 
+    /***
+     * This is used to initialize the number of unread messages shown in the UI.  Since
+     * we cannot tell if messages are read or unread, just initialize to 0 so that UI
+     * will only display a count of messages received after the application starts up.
+     */
     this.mentions = 0;
-    this.isRead = false;
+
+    /***
+     * When we receive chats and chat messages from the MS Graph API there is no information
+     * returned that would tell us if there are any unread messages in the chat, so always
+     * set this to false.
+     */
+    this.isRead = false
+
+    /***
+     * The isMember property does not appear to be used anywhere so it should not really
+     * matter what value we assign here (or if we assign a value at all).  However, since
+     * the current user is always a member of the chat/direct message we are creating we
+     * might as well assign "true" in case this gets used in the future.
+     */
     this.isMember = true
   }
 

--- a/lib/service/teams/teams-reaction.js
+++ b/lib/service/teams/teams-reaction.js
@@ -1,6 +1,6 @@
 const Reaction = require('../../model/reaction')
 
-const { parseEmoji } = require('./message-parser')
+const { parseReaction } = require('./message-parser')
 
 function normalizeReactionName(name) {
   const skin = name.indexOf('::')
@@ -13,7 +13,7 @@ function normalizeReactionName(name) {
 class TeamsReaction extends Reaction {
   constructor(account, name, count, userIds) {
     name = normalizeReactionName(name)
-    super(name, count, parseEmoji(account, 16, name))
+    super(name, count, parseReaction(account, 16, name))
     if (userIds.includes(account.currentUserId))
       this.reacted = true
   }

--- a/lib/service/teams/teams-thread.js
+++ b/lib/service/teams/teams-thread.js
@@ -62,7 +62,12 @@ class TeamsThread extends Thread {
   }
 
   async notifyReadImpl() {
-    // Slack does not seem to have an API to mark thread as read.
+    /***
+     * The MS Graph API does not expose a method for setting the ID of the last message 
+     * that has been read by the user.  However, the base class will throw an exception 
+     * if this method is not implemented in child classes, so we must have this here even
+     * though it does not do anything.
+     */
   }
 }
 

--- a/lib/service/teams/teams-thread.js
+++ b/lib/service/teams/teams-thread.js
@@ -49,11 +49,6 @@ class TeamsThread extends Thread {
   }
 
   async sendMessage(text) {
-    /***
-     * TODO (fall2020):
-     * Need to handle tags here as is done in the TeamsChannel class
-     */
-
     const response = await this.account.apiHelper.sendChannelMessageReply(this.account.id, this.channel.id, this.id, text)
 
     const message = new TeamsMessage(this.account, response)

--- a/lib/service/teams/teams-user.js
+++ b/lib/service/teams/teams-user.js
@@ -8,22 +8,25 @@ class TeamsUser extends User {
   // is needed when the TODO items below are addressed.
   constructor(account, event) {
 
-    /***
-     * TODO (fall2020):
-     * 1. The concept of status text seems to be quite different in Teams
-     *    than it is in Slack.  Need to determine how and where to best
-     *    handle for Teams.
-     * 2. Determine how to handle getting a user's icon/profile picture for MS Teams
-     *    In the desktop app the behavior appears to be to display a circle (in a random
-     *    color) containing the user's initials if the user does not have a profile picture
-     *    set and to display the profile picture if one is set.     
-     * 3. Determine if Teams has the concept of "bot" users and update this class accordingly.
-     *    For now, all users are treated as NOT being bot users.
-     * 4. Determine if Teams has the concept of status emoji and update this class accordingly.
-     ***/
-
     let phoneNumber = ''
+
+    /***
+     * With Slack, a user's icon/avatar is an image file that can be retrieved via an
+     * unauthenticated http GET.  For Microsoft Teams and the Graph API, retrieving the
+     * user's photo requires making an authenticated API call.  The Lounge Lizard architecture
+     * does not currently support making an authenticated http request to retrieve an image/avatar,
+     * so until that architecture is changed the icon property of this class will be set to an
+     * empty string (in the SlackUser class it is set to a URL for the image file).
+     */
     let icon = ''
+
+    /***
+     * The concept of status text seems to be quite different in Teams
+     * than it is in Slack.  In Teams, a user can set some status text
+     * that is displayed to other users for a set period of time.  However,
+     * The MS Graph API does not appear to expose any method to retrieve
+     * the status text.
+     */
     let statusText = ''
 
     phoneNumber = event.businessPhones.length > 0 ? event.businessPhones[0] : "";

--- a/lib/view/channel-item.js
+++ b/lib/view/channel-item.js
@@ -202,10 +202,6 @@ class ChannelItem {
     this.parent.account.leave(this.channel)
   }
   
-  /***
-   * TODO (fall2020):
-   * Eliminate tight coupling between this view and the Slack client
-   */
   async getUsers(){
 	  if (!this.hasGottenUsers) {
       const userList = await this.parent.account.getChannelMembers(this.channel.id)

--- a/lib/view/channel-item.js
+++ b/lib/view/channel-item.js
@@ -204,12 +204,12 @@ class ChannelItem {
   
   async getUsers(){
 	  if (!this.hasGottenUsers) {
-      const userList = await this.parent.account.getChannelMembers(this.channel.id)
+      const userList = await this.channel.getMembers()
 
       for (let u of userList) {
         this.userArray.push(u.name)
           
-			  let presence = await this.parent.account.getUserPresence(u.id)
+			  let presence = await this.channel.account.getUserPresence(u.id)
         this.presenceArray.push(presence)
       }
 		  this.hasGottenUsers = true

--- a/lib/view/users-searcher.js
+++ b/lib/view/users-searcher.js
@@ -8,12 +8,6 @@ const PADDING = 5
 const NAME_FONT = gui.Font.default().derive(0, 'bold', 'normal')
 const DESP_FONT = gui.Font.default().derive(2, 'normal', 'normal')
 
-/***
- * TODO (fall2020):
- * In its current implementation, this class is tighly coupled to the user
- * JSON that is returned from the Slack API.  It needs to be refactored to 
- * work with the service-agnostic User model instead.
- */
 class UsersSearcher {
   constructor(mainWindow) {
     this.mainWindow = mainWindow

--- a/lib/view/users-searcher.js
+++ b/lib/view/users-searcher.js
@@ -135,7 +135,7 @@ class UsersSearcher {
       } else if (this.account.canCreateDm) {
         /***
          * The code in this block remains tightly coupled to the Slack client (primarily
-         * because, in the case of the Slack client, joinDsM is returning a promise that
+         * because, in the case of the Slack client, joinDMAsync is returning a promise that
          * eventually resolves to a direct message) but because the MS Graph API does
          * not seem to support creating a new DM ("chat" in MS Graph API parlance), the code below
          * is never executed for a Teams account.

--- a/postman/Azure AD v2.0 Protocols.postman_collection.json
+++ b/postman/Azure AD v2.0 Protocols.postman_collection.json
@@ -233,7 +233,7 @@
 							]
 						},
 						"url": {
-							"raw": "https://login.microsoftonline.com/common/oauth2/v2.0/token",
+							"raw": "https://login.microsoftonline.com/organizations/oauth2/v2.0/token",
 							"protocol": "https",
 							"host": [
 								"login",
@@ -241,7 +241,7 @@
 								"com"
 							],
 							"path": [
-								"common",
+								"organizations",
 								"oauth2",
 								"v2.0",
 								"token"

--- a/supported-features.md
+++ b/supported-features.md
@@ -11,7 +11,7 @@ This document lists various features of a chat application and indicates whether
 | Get user photo           | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                |
 | Add custom emoji         | :white_check_mark: | :x:                | :x:                | :x:                | :x:                |
 | Set my status            | :white_check_mark: | :question:         | :white_check_mark: | :x:                | :x:                |
-| Get other users' status  | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                | :x:                |
+| Get other users' status  | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                |
 
 ## Channels
 

--- a/supported-features.md
+++ b/supported-features.md
@@ -5,42 +5,46 @@ This document lists various features of a chat application and indicates whether
 
 ## General Functionality ##
 
-| Feature                  | Slack              | LL for Slack       | MS Teams           | Graph API          | LL for Teams       |
-| ------------------------ | :----------------: | :----------------: | :----------------: | :----------------: | :----------------: |
-| Get team icon            | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                |
-| Get user photo           | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                |
-| Add custom emoji         | :white_check_mark: | :x:                | :x:                | :x:                | :x:                |
-| Set my status            | :white_check_mark: | :question:         | :white_check_mark: | :x:                | :x:                |
-| Get other users' status  | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                |
+| Feature                         | Slack              | LL for Slack       | MS Teams           | Graph API          | LL for Teams       |
+| ------------------------------- | :----------------: | :----------------: | :----------------: | :----------------: | :----------------: |
+| Get team icon                   | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                |
+| Get user photo                  | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                |
+| Add custom emoji                | :white_check_mark: | :x:                | :x:                | :x:                | :x:                |
+| Set my status                   | :white_check_mark: | :question:         | :white_check_mark: | :x:                | :x:                |
+| Get other users' status         | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                |
+| Set my status message           | :white_check_mark: | :x:                | :white_check_mark: | :question:         | :x:                |
+| Get other users' status message | :white_check_mark: | :question:         | :white_check_mark: | :question:         | :x:                |
 
 ## Channels
 
-| Feature         | Slack              | LL for Slack       | MS Teams           | Graph API          | LL for Teams       |
-| --------------- | :----------------: | :----------------: | :----------------: | :----------------: | :----------------: |
-| Get channels    | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-| Join channel    | :white_check_mark: | :white_check_mark: | :x:                | :x:                | :x:                |
-| Leave channel   | :white_check_mark: | :white_check_mark: | :x:                | :x:                | :x:                |
-| Create channel  | :white_check_mark: | :x:                | :white_check_mark: | :white_check_mark: | :x:                |
-| Star channel    | :white_check_mark: | :x:                | :x:                | :x:                | :x:                |
-| Manage channel  | :white_check_mark: | :x:                | :white_check_mark: | :white_check_mark: | :x:                |
-| Delete channel  | :white_check_mark: | :x:                | :white_check_mark: | :white_check_mark: | :x:                |
-| Get users       | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-| Get messages    | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-| Send message    | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| Feature               | Slack              | LL for Slack       | MS Teams           | Graph API          | LL for Teams       |
+| --------------------- | :----------------: | :----------------: | :----------------: | :----------------: | :----------------: |
+| Get channels          | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| Join channel          | :white_check_mark: | :white_check_mark: | :x:                | :x:                | :x:                |
+| Leave channel         | :white_check_mark: | :white_check_mark: | :x:                | :x:                | :x:                |
+| Create channel        | :white_check_mark: | :x:                | :white_check_mark: | :white_check_mark: | :x:                |
+| Star channel          | :white_check_mark: | :x:                | :x:                | :x:                | :x:                |
+| Manage channel        | :white_check_mark: | :x:                | :white_check_mark: | :white_check_mark: | :x:                |
+| Delete channel        | :white_check_mark: | :x:                | :white_check_mark: | :white_check_mark: | :x:                |
+| Get users             | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| Get messages          | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| Send message          | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| Set last read message | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                | :x:                |
 
 
 ## Chats (also called Conversations or Direct Messages)
 
-| Feature          | Slack              | LL for Slack       | MS Teams           | Graph API          | LL for Teams       |
-| ---------------- | :----------------: | :----------------: | :----------------: | :----------------: | :----------------: |
-| Get chats        | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-| Create chat      | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                | :x:                |
-| Close chat       | :white_check_mark: | :white_check_mark: | :x:                | :x:                | :x:                |
-| Leave chat       | :question:         | :x:                | :white_check_mark: | :question:         | :x:                |
-| Star chat        | :white_check_mark: | :x:                | :x:                | :x:                | :x:                |
-| Pin chat         | :x:                | :x:                | :white_check_mark: | :question:         | :x:                |
-| Get messages     | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-| Send message     | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| Feature               | Slack              | LL for Slack       | MS Teams           | Graph API          | LL for Teams       |
+| --------------------- | :----------------: | :----------------: | :----------------: | :----------------: | :----------------: |
+| Get chats             | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| Create chat           | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                | :x:                |
+| Close chat            | :white_check_mark: | :white_check_mark: | :x:                | :x:                | :x:                |
+| Leave chat            | :question:         | :x:                | :white_check_mark: | :question:         | :x:                |
+| Star chat             | :white_check_mark: | :x:                | :x:                | :x:                | :x:                |
+| Pin chat              | :x:                | :x:                | :white_check_mark: | :question:         | :x:                |
+| Get messages          | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| Send message          | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| Set last read message | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                | :x:                |
 
 ## Threads
 


### PR DESCRIPTION
This fixes the error that previously occurred when attempting to show users for a Slack DM.  Note that the app still does not support showing users for a multi-party DM, but an empty users window will now be displayed instead of an error occurring.